### PR TITLE
Switch default build action and "Run"

### DIFF
--- a/Moonscript.sublime-build
+++ b/Moonscript.sublime-build
@@ -1,12 +1,12 @@
 {
 	"file_regex": "^(?:(?:\t)|(?:.+: ))(.+):([0-9]+): (.*)$",
 	"selector": "source.moonscript",
-	"cmd": ["moon", "$file_name"],
+	"cmd": ["moonc", "$file_name"],
 
 	"variants": [
 		{   "name": "Run",
 			"shell": true,
-			"cmd": ["moonc", "$file_name"]
+			"cmd": ["moon", "$file_name"]
 		},
 		{   "name": "moonc: show output",
 			"shell": true,


### PR DESCRIPTION
This makes the actions more intuitive.

When you build something, it should compile the moonscript file rather than running it. Similarly, when you want to "Run" a moonscript file you wouldn't expect it to compile into Lua.
