### PR TITLE
Fix file + line regex, add lint build variants

### DIFF
--- a/Moonscript.sublime-build
+++ b/Moonscript.sublime-build
@@ -1,5 +1,5 @@
 {
-	"file_regex": "^(.*?\\.moon(?:script)?)\\t",
+	"file_regex": "^(.*?\\.moon)\\t",
 	"line_regex": "^\\s*\\[(\\d+)\\]",
 	"selector": "source.moonscript",
 	"cmd": ["moonc", "$file_name"],
@@ -28,7 +28,7 @@
 		{   "name": "moonc: run lint on file",
 			"shell": true,
 			"cmd": ["moonc", "-l", "$file_name"],
-			"file_regex": "^(.*?\\.moon(?:script)?)$",
+			"file_regex": "^(.*?\\.moon)$",
 			"line_regex": "^line (\\d+)"
 		},
 		{   "name": "moonc: run lint on project",

--- a/Moonscript.sublime-build
+++ b/Moonscript.sublime-build
@@ -1,5 +1,6 @@
 {
-	"file_regex": "^(?:(?:\t)|(?:.+: ))(.+):([0-9]+): (.*)$",
+	"file_regex": "^(.*?\\.moon(?:script)?)\\t",
+	"line_regex": "^\\s*\\[(\\d+)\\]",
 	"selector": "source.moonscript",
 	"cmd": ["moonc", "$file_name"],
 
@@ -23,6 +24,18 @@
 		{   "name": "moonc: compile project",
 			"shell": true,
 			"cmd": ["moonc", "*.moon"]
+		},
+		{   "name": "moonc: run lint on file",
+			"shell": true,
+			"cmd": ["moonc", "-l", "$file_name"],
+			"file_regex": "^(.*?\\.moon(?:script)?)$",
+			"line_regex": "^line (\\d+)"
+		},
+		{   "name": "moonc: run lint on project",
+			"shell": true,
+			"cmd": ["moonc", "-l", "*.moon"],
+			"file_regex": "^(.*?\\.moon(?:script)?)$",
+			"line_regex": "^line (\\d+)"
 		},
 		{   "name": "ldoc: File",
 			"shell": true,


### PR DESCRIPTION
Fixes the file and line regex patterns in the sublime-build file.
Adds lint build variants to sublime-build file to run lint on a file or project.

`moonc` outputs filename and line number on different lines, so a separate `line_regex` is needed in the build configuration.
